### PR TITLE
Add /bills List endpoint

### DIFF
--- a/lib/regaliator/endpoint/bill.rb
+++ b/lib/regaliator/endpoint/bill.rb
@@ -23,5 +23,9 @@ module Regaliator
     def self.xdata(id)
       Regaliator::Request.new("/bills/#{id}/xdata").get
     end
+
+    def self.list(params = {})
+      Regaliator::Request.new("/bills", params).get
+    end
   end
 end

--- a/test/regaliator/endpoint/bill_test.rb
+++ b/test/regaliator/endpoint/bill_test.rb
@@ -184,4 +184,14 @@ class Regaliator::BillTest < Minitest::Test
       assert_equal hash, response.data
     end
   end
+
+  def test_list
+    VCR.use_cassette('bills') do
+      response = Regaliator::Bill.list
+
+      assert response.success?
+
+      # TODO add stubbed response from VCR from api.regalii.dev
+    end
+  end
 end


### PR DESCRIPTION
The [Bills List endpoint](https://www.regalii.com/api/v3#list) appears to be missing from the gem.

I was unable to make a full working test as the config has:

```ruby
    Regaliator.configure do |config|
      config.api_key    = 'api-key'
      config.secret_key = 'secret-key'
      config.host       = 'api.regalii.dev'
      config.use_ssl    = false
    end
```

My assumption is `api.regalii.dev` is probably an alias for `localhost` for the development Regalii server which I would obviously not have access to.