### PR TITLE
remove unnecessary assignments

### DIFF
--- a/lib/regaliator/configuration.rb
+++ b/lib/regaliator/configuration.rb
@@ -5,18 +5,10 @@ module Regaliator
     attr_reader   :version
 
     def initialize
-      @api_key      = nil
-      @secret_key   = nil
-      @host         = nil
       @version      = Regaliator::API_VERSION
       @open_timeout = 10
       @read_timeout = 60
       @use_ssl      = true
-
-      @proxy_host   = nil
-      @proxy_port   = nil
-      @proxy_user   = nil
-      @proxy_pass   = nil
     end
 
     def secure?


### PR DESCRIPTION
By the fault ruby initialize instance variable to nil so this assignments are unnecessary.