### PR TITLE
send params as json in get request

### DIFF
--- a/lib/regaliator/request.rb
+++ b/lib/regaliator/request.rb
@@ -29,8 +29,8 @@ module Regaliator
     end
 
     def get
-      uri.query = URI.encode_www_form(params) if !params.empty?
       @http_request = Net::HTTP::Get.new(uri.request_uri)
+      @http_request.body = params.to_json if !params.empty?
 
       send_request
     end


### PR DESCRIPTION
This will allow us to send query params properly.
e.g. 
```
Regaliator.biller.credentials(q: { biller_type_eq: 'Credit Cards' })
```
TODO:
* make sure nothing else break
* fix the tests