### PR TITLE
Require time needed for `httpdate` instance method

### DIFF
--- a/lib/regaliator/request.rb
+++ b/lib/regaliator/request.rb
@@ -5,6 +5,7 @@ require 'openssl'
 require 'uri'
 require 'regaliator/response'
 require 'regaliator/version'
+require 'time'
 
 module Regaliator
   class Request
@@ -14,7 +15,7 @@ module Regaliator
 
     def initialize(config, endpoint, params = {})
       @config    = config
-      @timestamp = Time.now.utc.httpdate.to_s
+      @timestamp = Time.now.utc.httpdate
       @endpoint  = endpoint
       @params    = params
       @uri       = build_uri


### PR DESCRIPTION
Include dependency in order to use a method

As in: https://ruby-doc.org/stdlib-2.2.2/libdoc/time/rdoc/Time.html#method-c-httpdate
`You must require ‘time’ to use this method.`