### PR TITLE
update ruby version

### DIFF
--- a/regaliator.gemspec
+++ b/regaliator.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = ['>= 2.1.0', '< 2.7']
+  spec.required_ruby_version = ['>= 2.1.0', '< 3.0.0']
 
   spec.add_dependency 'json'
 


### PR DESCRIPTION
What's this PR do?

Regaliator now permit use ruby 2.7.2 version

Where should the reviewer start?

Any background context you want to provide?

This gem is used on api-x project this is necessary update this gem must accept the use the ruby 2.6.2. version

How should this be manually tested?

N/A

What are the relevant jira tickets?

[OPR-578](https://arcusfi.atlassian.net/browse/OPR-578)

What bug this fix? (If apply)

N/A